### PR TITLE
Replacing bean name "foo" with more meaningful value 

### DIFF
--- a/src/main/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtension.java
+++ b/src/main/java/org/springframework/data/jpa/repository/config/JpaRepositoryConfigExtension.java
@@ -164,7 +164,7 @@ public class JpaRepositoryConfigExtension extends RepositoryConfigurationExtensi
 		Object source = config.getSource();
 
 		registerIfNotAlreadyRegistered(new RootBeanDefinition(EntityManagerBeanDefinitionRegistrarPostProcessor.class),
-				registry, "foo", source);
+				registry, EM_BEAN_DEFINITION_REGISTRAR_POST_PROCESSOR_BEAN_NAME, source);
 
 		registerIfNotAlreadyRegistered(new RootBeanDefinition(JpaMetamodelMappingContextFactoryBean.class), registry,
 				JPA_MAPPING_CONTEXT_BEAN_NAME, source);


### PR DESCRIPTION
A bean probably shouldn't have "foo" as its name when everything else has meaningful values defined in constants.

Renamed bean and extracted constant alongside others referenced within the file.
